### PR TITLE
Release 0.8.4

### DIFF
--- a/Items/enha.lua
+++ b/Items/enha.lua
@@ -12,7 +12,7 @@
 
 end]]
 
---[[
+-- [[
 odric = SMODS.Enhancement {
 	object_type = "Enhancement",
 	key = "odric",
@@ -25,17 +25,15 @@ odric = SMODS.Enhancement {
         return { vars = { card.ability.extra.x_mult, card.ability.extra.extra } }
 	end,
     calculate = function(self, card, context, effect)
-       if context.other_card == G.play and not context.repetition and not card.debuff then 
+       if context.cardarea == G.hand and context.main_scoring then 
             local diamond_count = 0
             for i, v in pairs(G.play.cards) do
                 if v:is_suit("Diamonds") then
                     diamond_count = diamond_count + 1
                 end
             end
-                if diamond_count >= 1 and context.self == G.hand then
-                 return  {card.ability.extra.x_mult + diamond_count * card.ability.extra.extra}
-                end
-				return {x_mult = card.ability.extra.x_mult}
+               
+				return {x_mult = card.ability.extra.x_mult + diamond_count * card.ability.extra.extra}
             end
         end
 }
@@ -43,7 +41,7 @@ odric.force_value = "King"
 odric.force_suit = "Diamonds"
 --]]
 
---[[
+-- [[
 akroma = SMODS.Enhancement {
 	object_type = "Enhancement",
 	key = "akroma",
@@ -56,10 +54,10 @@ akroma = SMODS.Enhancement {
         return { vars = {card.ability.extra.mult_x} }
 	end,
     calculate = function(self, card, context, effect)
-        if context.cardarea == G.play and not context.repetition and not card.debuff then
+        if context.cardarea == G.play and context.main_scoring then
             if G.GAME.current_round.hands_played == 0 then
                 card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("mtg_haste_ex"), colour = G.ARGS.LOC_COLOURS.diamond})
-                effect.x_mult = card.ability.extra.mult_x
+                return {x_mult = card.ability.extra.mult_x}
             end
         end
     end
@@ -68,24 +66,22 @@ akroma.force_value = "Queen"
 akroma.force_suit = "Diamonds"
 --]]
 
---[[
+-- [[
 sublime = SMODS.Enhancement {
 	object_type = "Enhancement",
 	key = "sublime",
 	atlas = "mtg_atlas",
 	pos = { x = 8, y = 5 },
-	config = { extra = {mult_solo = 2}},
+	config = { extra = { x_mult = 2}},
     overrides_base_rank = true,
     weight = 5,
 	loc_vars = function(self, info_queue, card)
-        return { vars = { card.ability.extra.mult_solo} }
+        return { vars = { card.ability.extra.x_mult} }
 	end,
     
     calculate = function(self, card, context, effect)
-        print(inspect(context))
-
-        if context.cardarea == G.hand and not context.repetition and not card.debuff and context.main_scoring then
-         return card.ability.extra.mult_solo
+         if context.cardarea == G.hand and context.main_scoring then
+         return {x_mult = card.ability.extra.x_mult}
         
         
         end
@@ -149,7 +145,7 @@ urza = SMODS.Enhancement {
 
 	end,
     calculate = function(self, card, context, effect)
-        if context.cardarea == G.play and not context.repetition and not card.debuff then
+        if context.cardarea == G.play and context.main_scoring then
             local non_steel_cards = {}
             for i = 1, #G.hand.cards do
                 if G.hand.cards[i].config.center_key ~= "m_steel" then non_steel_cards[#non_steel_cards+1] = G.hand.cards[i] end
@@ -434,8 +430,8 @@ kikijiki = SMODS.Enhancement {
 
 	end,
     calculate = function(self, card, context, effect)
-        if context.cardarea == G.hand and not context.repetition and not card.debuff then
-            if G.GAME.current_round.hands_played == 0 and #context.full_hand == 1 then
+        if context.cardarea == G.hand and context.main_scoring then
+            if G.GAME.current_round.hands_played == 0 then
                 G.E_MANAGER:add_event(Event({
                     func = function()
                         G.playing_card = (G.playing_card and G.playing_card + 1) or 1

--- a/Items/lands.lua
+++ b/Items/lands.lua
@@ -186,11 +186,11 @@ SMODS.Consumable {
         for i=1, #G.hand.highlighted do
             G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.1,func = function()
                 if G.hand.highlighted[i].base.suit == 'suit_clovers.key' then
-                  -- do club things
+                  -- do clover things
                     Card.set_ability(G.hand.highlighted[i], Forest_land, nil)
                     
                 else
-                  -- do non-club things
+                  -- do non-clover things
                     SMODS.change_base(G.hand.highlighted[i],'suit_clovers.key',nil)
                 end
                 return true
@@ -269,7 +269,7 @@ SMODS.Consumable {
 }
 --]]
 
---[[
+-- [[
 SMODS.Consumable {
     object_type = "Consumable",
     set = "Land",
@@ -289,10 +289,44 @@ SMODS.Consumable {
             return { vars = { 0 } }
         end
     end,
-    use = function (self, card, area, copier)
-        local used_land = card or copier
+    use = function(self, card, area, copier)
+        local used_tarot = card or copier
         
-    end
+        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
+            play_sound('tarot1')
+            used_tarot:juice_up(0.3, 0.5)
+            return true end }))
+        for i=1, #G.hand.highlighted do
+            local percent = 1.15 - (i-0.999)/(#G.hand.highlighted-0.998)*0.3
+            G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.15,func = function() G.hand.highlighted[i]:flip();play_sound('card1', percent);G.hand.highlighted[i]:juice_up(0.3, 0.3);return true end }))
+        end
+        delay(0.2)
+        for i=1, #G.hand.highlighted do
+            G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.1,func = function()
+                if G.hand.highlighted[i].base.suit == 'Spades' then
+                  -- do spade things
+                    Card.set_ability(G.hand.highlighted[i], Swamp_land, nil)
+                    
+                else
+                  -- do non-spade things
+                    SMODS.change_base(G.hand.highlighted[i],'Spades',nil)
+                end
+                return true
+              end,}))
+        end
+   
+        
+        for i=1, #G.hand.highlighted do
+            local percent = 0.85 + (i-0.999)/(#G.hand.highlighted-0.998)*0.3
+            G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.15,func = function() G.hand.highlighted[i]:flip();play_sound('tarot2', percent, 0.6);G.hand.highlighted[i]:juice_up(0.3, 0.3);return true end }))
+        end
+        
+        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2,func = function() G.hand:unhighlight_all(); return true end }))
+        delay(0.5)
+        
+        
+    end,        
+            
 }
 
 --]]
@@ -329,11 +363,11 @@ SMODS.Consumable {
         for i=1, #G.hand.highlighted do
             G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.1,func = function()
                 if G.hand.highlighted[i].base.suit == 'Diamonds' then
-                  -- do club things
+                  -- do diamond things
                     Card.set_ability(G.hand.highlighted[i], Plains_land, nil)
                     
                 else
-                  -- do non-club things
+                  -- do non-diamond things
                     SMODS.change_base(G.hand.highlighted[i],'Diamonds',nil)
                 end
                 return true
@@ -419,7 +453,7 @@ Plains_land = SMODS.Enhancement {
       end
 }
 
---[[
+-- [[
 Swamp_land = SMODS.Enhancement {
     object_type = "Enhancement",
     name = "mtg-Swamp_land",

--- a/Items/magic.lua
+++ b/Items/magic.lua
@@ -23,7 +23,7 @@ SMODS.ConsumableType {
 SMODS.UndiscoveredSprite {
     object_type = "UndiscoveredSprite",
     key = "Magic",
-    atlas = "mtg_atlas",
+    atlas = "mtg_back",
     pos = {
         x = 0,
         y = 1,
@@ -1343,6 +1343,30 @@ SMODS.Booster {
   weight = 0.48,
   create_card = function(self, card)
       return create_card("Magic", G.pack_cards, nil, nil, true, true, nil, "mtg_magic")
+  end,
+  ease_background_colour = function(self)
+      ease_colour(G.C.DYN_UI.MAIN, G.C.SET.Magic)
+      ease_background_colour({ new_colour = G.C.SET.Magic, special_colour = G.C.BLACK, contrast = 2 })
+  end,
+  loc_vars = function(self, info_queue, card)
+      return { vars = { card.config.center.config.choose, card.ability.extra } }
+  end,
+  group_key = "k_mtg_magic_pack",
+}
+
+-- bloomborrow Land Cards
+SMODS.Booster {
+  object_type = "Booster",
+  key = "magic_pack_5",
+  kind = "Magic",
+  atlas = "land_pack",
+  pos = { x = 0, y = 0 },
+  config = {extra = 4, choose = 1 },
+  cost = 5,
+  order = 1,
+  weight = 0.48,
+  create_card = function(self, card)
+      return create_card("Land", G.pack_cards, nil, nil, true, true, nil, "mtg_magic")
   end,
   ease_background_colour = function(self)
       ease_colour(G.C.DYN_UI.MAIN, G.C.SET.Magic)

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -507,6 +507,13 @@ return {
                     "is scored give {X:mult,C:white}X#1#{} Mult"
                 },
             },
+            m_mtg_Swamp_land = {
+                name = "Swamp Land",
+                text = {
+                    "When card with the {C:spade}Spade{} suit",
+                    "is scored give {X:mult,C:white}X#1#{} Mult"
+                },
+            },
         },
        
         Tarot = {
@@ -514,7 +521,7 @@ return {
                 name = "Forest",
                 text = {
                     "Converts up to",
-                    "{C:attention}3{} selected cards",
+                    "{C:attention}#1#{} selected cards",
                     "to {C:clover}Clovers{}"
                 },
             },
@@ -803,7 +810,7 @@ return {
                 text = {
                     "Converts up to",
                     "{C:attention}#1#{} selected cards",
-                    "to {C:club}Clubs{}"
+                    "to {C:spade}Spades{}"
                 },
             },
         },
@@ -994,6 +1001,13 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of up to",
                     "{C:attention}#2#{C:Magic} Magic{} cards"
+                }
+            },
+            p_mtg_magic_pack_5 = {
+                name = "Bloomburrow Land Pack",
+                text = {
+                    "Choose {C:attention}#1#{} of up to",
+                    "{C:attention}#2#{C:Magic} Land{} cards"
                 }
             },
             mtg_greedy_seal = {

--- a/mtg.lua
+++ b/mtg.lua
@@ -87,7 +87,7 @@ SMODS.Atlas({
 	py = 95,
 })
 --]]
---[[
+-- [[
 SMODS.Atlas({
 	object_type = "Atlas",
 	key = "swamp",
@@ -108,6 +108,13 @@ SMODS.Atlas({
 	object_type = "Atlas",
 	key = "mtg_back",
 	path = "un_back.png",
+	px = 71,
+	py = 95,
+})
+SMODS.Atlas({
+	object_type = "Atlas",
+	key = "land_pack",
+	path = "land_booster.png",
 	px = 71,
 	py = 95,
 })


### PR DESCRIPTION
What's New:
Added a new consumable type called "Lands" that give the Land enhancement to your cards or convert them to the corresponding suit if they are not already the correct suit.

Added a new booster pack that you can get the Land consumables from.

General Bugfixes and Updates:
Updated the code for all existing Enhancements to be up to date with Steamodded 1314b

Fixed some code with Obliterate that would cause you to loose the run if cryptid was enabled

Compatibility:
Magic the Jokering (MTJ) should be compatible with cryptid (if not check the Issues section to see if there is any updates)

Known issues:
When cryptid is enabled, Relentless Rats do not appear negative 100% of the time when while having Relentless Rats

Future Plans/Ideas:
Make a a separate branch/fork that is geared towards being sure it is mod compatible and have the main branch be the stand alone

Make a Discord server so everything can be more streamlined and centralized

And add more cards to the mod (check the discussions if you want to suggest stuff)